### PR TITLE
Fix numpy 2.0 compatibility

### DIFF
--- a/qq-snooker-helper/extract.py
+++ b/qq-snooker-helper/extract.py
@@ -10,8 +10,8 @@ import matplotlib.pyplot as plt
 # RGB转换HSV空间
 def rgb2hsv(rgb):
     hsv = np.zeros(rgb.shape, dtype=np.float32)
-    cmax = rgb.max(axis=-1)
-    crng = rgb.ptp(axis=-1)
+    cmax = np.max(rgb, axis=-1)
+    crng = np.ptp(rgb, axis=-1)
     np.clip(cmax, 1, 255, out=hsv[:,:,1])
     np.divide(crng, hsv[:,:,1], out=hsv[:,:,1])
     np.divide(cmax, 255, out=hsv[:,:,2])

--- a/qq-snooker-helper/frame.pyw
+++ b/qq-snooker-helper/frame.pyw
@@ -81,6 +81,6 @@ if __name__ == '__main__':
     #rad_black8.pack(side='left')
     btn_mode.pack(side='left')
     thread = Thread(target=hold)
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
     top.mainloop()


### PR DESCRIPTION
## Summary
- Replace deprecated ndarray.ptp call with np.ptp in rgb2hsv to support NumPy 2.0+
- Use Thread.daemon attribute instead of deprecated setDaemon

## Testing
- `python -m py_compile extract.py frame.pyw robot.py table.py`
- `python - <<'PY'
import numpy as np
from extract import rgb2hsv_lut
img = np.zeros((2,2,3), dtype=np.uint8)
hsv = rgb2hsv_lut(img)
print('hsv', hsv.shape, hsv.dtype, hsv)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689cddf623c48326a80a8916a5436f55