### PR TITLE
Fix numpy 2.0 compatibility

### DIFF
--- a/qq-snooker-helper/extract.py
+++ b/qq-snooker-helper/extract.py
@@ -10,8 +10,8 @@ import matplotlib.pyplot as plt
 # RGB转换HSV空间
 def rgb2hsv(rgb):
     hsv = np.zeros(rgb.shape, dtype=np.float32)
-    cmax = rgb.max(axis=-1)
-    crng = rgb.ptp(axis=-1)
+    cmax = np.max(rgb, axis=-1)
+    crng = np.ptp(rgb, axis=-1)
     np.clip(cmax, 1, 255, out=hsv[:,:,1])
     np.divide(crng, hsv[:,:,1], out=hsv[:,:,1])
     np.divide(cmax, 255, out=hsv[:,:,2])
@@ -86,8 +86,9 @@ def find_ground(img, tor=5):
     hist = np.bincount(lab.ravel())
     if hist[1:].max() < 1e4: return None
     if np.argmax(hist[1:])==0: return None
-    msk = lab == np.argmax(hist[1:]) + 1
-    sr, sc = ndimg.find_objects(msk)[0]
+    idx = np.argmax(hist[1:]) + 1
+    sr, sc = ndimg.find_objects(lab)[idx-1]
+    msk = lab == idx
     loc = sr.start, sc.start
     size = sr.stop - loc[0], sc.stop - loc[1]
     return loc, size, sr, sc, msk[sr, sc]

--- a/qq-snooker-helper/frame.pyw
+++ b/qq-snooker-helper/frame.pyw
@@ -81,6 +81,6 @@ if __name__ == '__main__':
     #rad_black8.pack(side='left')
     btn_mode.pack(side='left')
     thread = Thread(target=hold)
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
     top.mainloop()


### PR DESCRIPTION
## Summary
- Replace deprecated ndarray.ptp call with np.ptp in rgb2hsv to support NumPy 2.0+
- Use Thread.daemon attribute instead of deprecated setDaemon
- Pass label array into ndimage.find_objects to avoid numpy.bool TypeError

## Testing
- `python -m py_compile qq-snooker-helper/extract.py qq-snooker-helper/frame.pyw qq-snooker-helper/robot.py qq-snooker-helper/table.py`
- `python - <<'PY'
import sys, numpy as np
sys.path.append('qq-snooker-helper')
from extract import rgb2hsv_lut, find_ground
img = np.zeros((300,300,3), dtype=np.uint8)
hsv = rgb2hsv_lut(img)
res = find_ground(hsv)
print('find_ground result:', res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689cddf623c48326a80a8916a5436f55